### PR TITLE
[BUGFIX] 회원가입시 createdBy, updatedBy가 null로 들어가는 이슈 

### DIFF
--- a/src/main/java/com/project/dugoga/domain/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/project/dugoga/domain/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -50,4 +50,9 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     public Review save(Review review) {
         return reviewJpaRepository.save(review);
     }
+
+    @Override
+    public Optional<Review> findByIdWithStoreAndDeletedAtIsNull(UUID reviewId) {
+        return reviewJpaRepository.findByIdWithStoreAndDeletedAtIsNull(reviewId);
+    }
 }

--- a/src/main/java/com/project/dugoga/domain/user/domain/model/entity/User.java
+++ b/src/main/java/com/project/dugoga/domain/user/domain/model/entity/User.java
@@ -1,5 +1,6 @@
 package com.project.dugoga.domain.user.domain.model.entity;
 
+import com.project.dugoga.domain.user.application.dto.SignupRequestDto;
 import com.project.dugoga.domain.user.domain.model.enums.UserRoleEnum;
 import com.project.dugoga.global.entity.BaseEntity;
 import com.project.dugoga.global.exception.BusinessException;

--- a/src/main/java/com/project/dugoga/global/config/audit/SecurityAuditorAware.java
+++ b/src/main/java/com/project/dugoga/global/config/audit/SecurityAuditorAware.java
@@ -13,9 +13,15 @@ public class SecurityAuditorAware implements AuditorAware<Long> {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated()) {
-            return Optional.empty();
+            return Optional.of(0L);
         }
 
-        return Optional.of(((CustomUserDetails)authentication.getPrincipal()).getId());
+        Object principal = authentication.getPrincipal();
+
+        if(principal instanceof CustomUserDetails userDetails) {
+            return Optional.of(userDetails.getId());
+        }
+
+        return Optional.of(0L);
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #149 

## 📝 작업 내역
- 인증정보가 없거나 비로그인인 경우에는 AuditorAware에서 0 반환되도록 수정했습니다.

## 💡 PR 특이사항

`1. 초기에 createdBy, updatedBy를 0으로 생성하고 생성된 userId로 update` 
`2. createdBy, updatedBy컬럼을 nullable로 허용하고 생성된 userId로 update`

이전에 위와 같은 방식 중에 고민을 했었습니다. Auditing은 `누가 데이터를 생성/수정 했는지 추적하기 위한 감사 목적`으로 사용되는 경우가 많아서, createdBy가 꼭 본인일 필요가 없다. 오히려 0을 표기해서 `시스템이 생성한 데이터`로 볼 수 있기 때문에 createdBy는 0으로 놓고 업데이트를 하지 않아도 되지 않을까라는 의견입니다..! 팀원들의 의견을 들어보고 싶습니다
https://java-kkwagjaba.tistory.com/26?utm_source=chatgpt.com